### PR TITLE
글 리스트 API

### DIFF
--- a/supabase/functions/briefInfo/briefInfo.type.ts
+++ b/supabase/functions/briefInfo/briefInfo.type.ts
@@ -1,0 +1,9 @@
+interface Post {
+  tag_id: number;
+}
+
+export interface Station {
+  station_id: number;
+  station_name: string;
+  post: Post[];
+}

--- a/supabase/functions/briefInfo/index.ts
+++ b/supabase/functions/briefInfo/index.ts
@@ -5,22 +5,8 @@
 // Setup type definitions for built-in Supabase Runtime APIs
 /// <reference types="https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts" />
 
-import { createClient } from "npm:@supabase/supabase-js@2.39.3";
-
-const supabase = createClient(
-  Deno.env.get("SUPABASE_URL")!,
-  Deno.env.get("SUPABASE_ANON_KEY")!,
-);
-
-interface Post {
-  tag_id: number;
-}
-
-interface Station {
-  station_id: number;
-  station_name: string;
-  post: Post[];
-}
+import { supabase } from "../shared/client.ts";
+import { Station } from "./briefInfo.type.ts";
 
 Deno.serve(async () => {
   const { data, error } = await supabase
@@ -53,7 +39,7 @@ Deno.serve(async () => {
   const stations = data.map((station: Station) => {
     // 가장 많이 사용된 tagId 찾기
     const tagCounts = station.post.reduce(
-      (acc: { [key: number]: number }, post: Post) => {
+      (acc: { [key: number]: number }, post) => {
         acc[post.tag_id] = (acc[post.tag_id] || 0) + 1;
         return acc;
       },

--- a/supabase/functions/postList/index.ts
+++ b/supabase/functions/postList/index.ts
@@ -1,0 +1,100 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+import { supabase } from "../shared/client.ts";
+
+// Setup type definitions for built-in Supabase Runtime APIs
+/// <reference types="https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts" />
+
+async function handleRequest(request: Request) {
+  const url = new URL(request.url);
+  const stationId = url.searchParams.get("stationId");
+  const pageSize = Number(url.searchParams.get("pageSize") || "1");
+  // 페이지 1부터 시작
+  const pageNumber = Number(url.searchParams.get("pageNumber") || "1") - 1;
+  const tagId = url.searchParams.get("tagId");
+
+  if (!stationId) {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        code: 400,
+        message: "station_id is required",
+        data: {},
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  let query = supabase
+    .from("post")
+    .select(
+      `
+    id: post_id,
+    createdTime: created_datetime,
+    imageUrl: image!left(
+      image_url
+    ),
+    tagId: tag_id,
+    like,
+    content,
+    tag!inner(
+      nickname
+    )
+    `,
+      { count: "exact" },
+    )
+    .eq("station_id", stationId)
+    .range(pageNumber * pageSize, (pageNumber + 1) * pageSize - 1)
+    .order("created_datetime", { ascending: false });
+
+  if (tagId && tagId !== "0") {
+    query = query.eq("tag_id", tagId);
+  }
+
+  const { data: posts, error, count } = await query;
+
+  if (error) {
+    console.error(error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        code: 500,
+        message: "서버 오류",
+        data: {},
+        error,
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const pageInfoDto = {
+    page: pageNumber + 1,
+    size: pageSize,
+    totalElements: count || 0,
+    totalPages: Math.ceil(count || 0 / pageSize),
+  };
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      code: 200,
+      message: "Ok",
+      data: { posts },
+      pageInfoDto: pageInfoDto,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+Deno.serve(handleRequest);

--- a/supabase/functions/shared/client.ts
+++ b/supabase/functions/shared/client.ts
@@ -1,0 +1,6 @@
+import { createClient } from "npm:@supabase/supabase-js@2.39.3";
+
+export const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_ANON_KEY")!,
+);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #3 

## 🔨 작업 내용

> - 글 리스트를 불러오는 edge function 작성
> - 역별, 태그별 호출 가능
> - 페이지네이션 가능

## 🤯 어려웠던 부분
> - tag table의 RLS 설정이 안되어있어서 join을 해도 데이터를 불러올 수 없었다. 데이터가 안나오는 원인을 몰라서 시간이 오래걸렸음